### PR TITLE
fix gathering duplication bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,8 +259,9 @@ export DJANGO_SECRET_KEY=<<production Django secret key>>
 * backup current db to container `docker-compose -f production.yml exec postgres backup`
 * list backup files in container `docker-compose -f production.yml exec postgres backups`
 * When postgres container is up, copy all backup files from container to dev local computer `docker cp $(docker-compose -f production.yml ps -q postgres):/backups ./backups`
-* When postgres container is up, copy all backup files from dev local computer to container `docker cp ./backups/* $(docker-compose -f production.yml ps -q postgres):/backups/`
+* When postgres container is up, copy all backup files from dev local computer to container `docker cp ./backups $(docker-compose -f production.yml ps -q postgres):/`
 * When postgres container is up, restore a backup from a backup file in container `docker-compose -f production.yml exec postgres restore backup_2018_03_13T09_05_07.sql.gz`
+* When postgres container is up, remove all backups from docker `docker-compose -f production.yml exec postgres sh -c "rm /backups/*"`
 * print INSERT commands for a table `docker-compose -f production.yml exec postgres pg_dump --column-inserts --data-only --table=<<table name>> -d attendees --username=<<POSTGRES_USER in .envs/.production/.postgres>>`
 * Enter postgres db console by `docker-compose -f production.yml exec postgres psql -d attendees --username=<<POSTGRES_USER in .envs/.production/.postgres>>`
 </details>

--- a/attendees/occasions/services/attendance_service.py
+++ b/attendees/occasions/services/attendance_service.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import pytz
 from django.conf import settings
 from django.db.models import F, Q, CharField, Value, When, Case, Count
 from django.db.models.functions import Concat, Trim
@@ -321,32 +322,55 @@ class AttendanceService:
         """
         Idempotently create attendances based on the following params and attendingmeet.
 
-        :param begin:
-        :param end:
-        :param meet:
-        :param meet_slug:
-        :param user_time_zone:
-        :param attendee_id:
-        :return: number of attendances created
+        :param begin: ISO format datetime string
+        :param end: ISO format datetime string
+        :param meet: Meet instance
+        :param meet_slug: meet slug for error reporting
+        :param user_time_zone: DEPRECATED - timezone is now derived from meet.infos['default_time_zone'] since users can be anywhere
+        :param attendee_id: optional attendee id to filter
+        :return: dict with success status and number of attendances created
         """
         number_created = 0
         iso_time_format = "%Y-%m-%dT%H:%M:%S.%f%z"
         user_begin_time = datetime.strptime(begin, iso_time_format)
         user_end_time = datetime.strptime(end, iso_time_format)
 
+        # Validate that meet has default_time_zone configured
+        if not meet or not meet.infos.get('default_time_zone'):
+            results = {
+                "success": False,
+                "attendance_created": 0,
+                "meet_slug": meet.slug if meet else meet_slug,
+                "begin": begin,
+                "end": end,
+                "explain": (
+                    f"CRITICAL: No meet or Meet '{meet.slug if meet else meet_slug}' must have "
+                    f"'default_time_zone' configured in infos to avoid timezone ambiguity. "
+                    f"Please set meet.infos['default_time_zone'] (e.g., 'America/Los_Angeles')."
+                ),
+            }
+            return results
+
+        # Use meet's canonical timezone instead of user_time_zone parameter
+        canonical_time_zone = pytz.timezone(meet.infos['default_time_zone'])
+
         if meet and user_end_time > user_begin_time:
             begin_time = (
                 user_begin_time if meet.start < user_begin_time else meet.start
-            ).astimezone(user_time_zone)
+            ).astimezone(canonical_time_zone)
             end_time = (
                 user_end_time if meet.finish > user_end_time else meet.finish
-            ).astimezone(user_time_zone)
+            ).astimezone(canonical_time_zone)
 
             for gathering in meet.gathering_set.filter(finish__gte=begin_time, start__lte=end_time, infos__generate_attendance=True):
+                # Force timezone conversion to canonical timezone for consistent comparison
+                canonical_gathering_start = gathering.start.astimezone(canonical_time_zone)
+                canonical_gathering_finish = gathering.finish.astimezone(canonical_time_zone)
+
                 filters = {
                     'meet': meet,
-                    'finish__gte': gathering.start,
-                    'start__lte': gathering.finish,
+                    'finish__gte': canonical_gathering_start,
+                    'start__lte': canonical_gathering_finish,
                 }
                 if attendee_id:
                     filters['attending__attendee_id'] = attendee_id

--- a/attendees/occasions/services/gathering_service.py
+++ b/attendees/occasions/services/gathering_service.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+import pytz
 from address.models import Address
 from django.contrib.contenttypes.models import ContentType
 from rest_framework.utils import json
@@ -99,27 +100,46 @@ class GatheringService:
     def batch_create(begin, end, meet_slug, duration, meet, user_time_zone):
         """
         Idempotently create gatherings based on the following params.  Created Gatherings are associated with Occurrence
-        Todo 20210821 Hardcoded tzinfo for strptime to get event.get_occurrences() working as of now, needs improvement.
-        :param begin:
-        :param end:
-        :param meet_slug:
-        :param duration:
-        :param meet:
-        :param user_time_zone:
-        :return: number of gatherings created
+
+        :param begin: ISO format datetime string
+        :param end: ISO format datetime string
+        :param meet_slug: meet slug for error reporting
+        :param duration: gathering duration in minutes
+        :param meet: Meet instance
+        :param user_time_zone: DEPRECATED - timezone is now derived from meet.infos['default_time_zone'] since users can be anywhere
+        :return: dict with success status and number of gatherings created
         """
         number_created = 0
         iso_time_format = "%Y-%m-%dT%H:%M:%S.%f%z"
         user_begin_time = datetime.strptime(begin, iso_time_format)
         user_end_time = datetime.strptime(end, iso_time_format)
 
+        # Validate that meet has default_time_zone configured
+        if not meet or not meet.infos.get('default_time_zone'):
+            results = {
+                "success": False,
+                "number_created": 0,
+                "meet_slug": meet.slug if meet else meet_slug,
+                "begin": begin,
+                "end": end,
+                "explain": (
+                    f"CRITICAL: Meet '{meet.slug if meet else meet_slug}' must have "
+                    f"'default_time_zone' configured in infos to avoid timezone ambiguity. "
+                    f"Please set meet.infos['default_time_zone'] (e.g., 'America/Los_Angeles')."
+                ),
+            }
+            return results
+
+        # Use meet's canonical timezone instead of user_time_zone parameter
+        canonical_time_zone = pytz.timezone(meet.infos['default_time_zone'])
+
         if meet and user_end_time > user_begin_time:
             begin_time = (
                 user_begin_time if meet.start < user_begin_time else meet.start
-            ).astimezone(user_time_zone)
+            ).astimezone(canonical_time_zone)
             end_time = (
                 user_end_time if meet.finish > user_end_time else meet.finish
-            ).astimezone(user_time_zone)
+            ).astimezone(canonical_time_zone)
             gathering_time = (
                 timedelta(minutes=duration) if duration and duration > 0 else None
             )
@@ -144,19 +164,23 @@ class GatheringService:
                         if er.distinction != 'source':
                             del infos['generate_attendance']  # no attendance will be generated for every location calendar
 
+                        # Force timezone conversion to canonical timezone to prevent duplicates
+                        canonical_start = occurrence.start.astimezone(canonical_time_zone)
+                        canonical_end = occurrence_end.astimezone(canonical_time_zone)
+
                         gathering, gathering_created = Gathering.objects.get_or_create(
                             meet=meet,
                             site_id=site_id,
                             site_type=site_type,
-                            start=occurrence.start,
+                            start=canonical_start,
                             defaults={
                                 "site_type": site_type,
                                 "site_id": site_id,
                                 "meet": meet,
-                                "start": occurrence.start,
-                                "finish": occurrence_end,
+                                "start": canonical_start,
+                                "finish": canonical_end,
                                 "infos": infos,
-                                "display_name": f'{meet.display_name} {occurrence.start.strftime("%Y/%m/%d,%H:%M %p %Z")} at {meet.site}'[0:254],
+                                "display_name": f'{meet.display_name} {canonical_start.strftime("%Y/%m/%d,%H:%M %p %Z")} at {meet.site}'[0:254],
                             },
                         )  # don't update gatherings if exist since it may have customizations
 

--- a/attendees/occasions/views/api/series_attendances.py
+++ b/attendees/occasions/views/api/series_attendances.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from rest_framework import viewsets
 from rest_framework.response import Response
+from rest_framework import status
 
 from attendees.occasions.models import Meet
 from attendees.occasions.serializers import BatchAttendancesSerializer
@@ -18,7 +19,10 @@ from attendees.users.authorization import RouteGuard
 @method_decorator([login_required], name='dispatch')
 class SeriesAttendancesViewSet(RouteGuard, viewsets.ViewSet):
     """
-    API endpoint that allows batch creation of gatherings.
+    API endpoint that allows batch creation of gatherings and attendances.
+
+    IMPORTANT: Timezone is determined solely by meet.infos['default_time_zone'] since users can be anywhere.
+    User cookie timezone is ignored to ensure data consistency across manual and automated operations.
     """
 
     serializer_class = BatchAttendancesSerializer  # Required for the Browsable API renderer to have a nice form.
@@ -30,26 +34,36 @@ class SeriesAttendancesViewSet(RouteGuard, viewsets.ViewSet):
             slug=request.data["meet_slug"],
             assembly__division__organization=organization,
         )
-        tzname = (
-            request.COOKIES.get("timezone")
-            or meet.infos["default_time_zone"]
-            or organization.infos["default_time_zone"]
-            or settings.CLIENT_DEFAULT_TIME_ZONE
-        )
+
+        # Validate meet has default_time_zone configured - critical for data consistency
+        if not meet.infos.get("default_time_zone"):
+            return Response({
+                "success": False,
+                "error": (
+                    f"Meet '{meet.slug}' must have 'default_time_zone' configured in infos. "
+                    f"Please configure meet.infos['default_time_zone'] (e.g., 'America/Los_Angeles') "
+                    f"to prevent timezone ambiguity and data duplication."
+                ),
+                "meet_slug": meet.slug,
+            }, status=status.HTTP_400_BAD_REQUEST)
+
+        # Use meet's canonical timezone - ignore user cookie for data consistency
+        tzname = meet.infos["default_time_zone"]
+
         gathering_results = GatheringService.batch_create(
             begin=request.data.get('begin'),
             end=request.data.get('end'),
             meet_slug=request.data.get('meet_slug'),
             duration=request.data.get('duration'),
             meet=meet,
-            user_time_zone=pytz.timezone(parse.unquote(tzname)),
+            user_time_zone=pytz.timezone(tzname),  # Parameter name kept for backwards compatibility
         )
         attendance_results = AttendanceService.batch_create(
             begin=request.data.get('begin'),
             end=request.data.get('end'),
             meet_slug=request.data.get('meet_slug'),
             meet=meet,
-            user_time_zone=pytz.timezone(parse.unquote(tzname)),
+            user_time_zone=pytz.timezone(tzname),  # Parameter name kept for backwards compatibility
             attendee_id=request.data.get('attendee'),
         )
         attendance_results['gathering_generation_success'] = gathering_results['success']

--- a/attendees/occasions/views/api/series_gatherings.py
+++ b/attendees/occasions/views/api/series_gatherings.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from rest_framework import viewsets
 from rest_framework.response import Response
+from rest_framework import status
 
 from attendees.occasions.models import Meet
 from attendees.occasions.serializers import BatchGatheringsSerializer
@@ -19,6 +20,9 @@ from attendees.users.authorization import RouteGuard
 class SeriesGatheringsViewSet(RouteGuard, viewsets.ViewSet):
     """
     API endpoint that allows batch creation of gatherings.
+
+    IMPORTANT: Timezone is determined solely by meet.infos['default_time_zone'] since users can be anywhere
+    User cookie timezone is ignored to ensure data consistency across manual and automated operations.
     """
 
     serializer_class = BatchGatheringsSerializer  # Required for the Browsable API renderer to have a nice form.
@@ -30,19 +34,29 @@ class SeriesGatheringsViewSet(RouteGuard, viewsets.ViewSet):
             slug=request.data["meet_slug"],
             assembly__division__organization=organization,
         )
-        tzname = (
-            request.COOKIES.get("timezone")
-            or meet.infos["default_time_zone"]
-            or organization.infos["default_time_zone"]
-            or settings.CLIENT_DEFAULT_TIME_ZONE
-        )
+
+        # Validate meet has default_time_zone configured - critical for data consistency
+        if not meet.infos.get("default_time_zone"):
+            return Response({
+                "success": False,
+                "error": (
+                    f"Meet '{meet.slug}' must have 'default_time_zone' configured in infos. "
+                    f"Please configure meet.infos['default_time_zone'] (e.g., 'America/Los_Angeles') "
+                    f"to prevent timezone ambiguity and data duplication."
+                ),
+                "meet_slug": meet.slug,
+            }, status=status.HTTP_400_BAD_REQUEST)
+
+        # Use meet's canonical timezone - ignore user cookie for data consistency
+        tzname = meet.infos["default_time_zone"]
+
         results = GatheringService.batch_create(
             begin=request.data.get('begin'),
             end=request.data.get('end'),
             meet_slug=request.data.get('meet_slug'),
             duration=request.data.get('duration'),
             meet=meet,
-            user_time_zone=pytz.timezone(parse.unquote(tzname)),
+            user_time_zone=pytz.timezone(tzname),  # Parameter name kept for backwards compatibility
         )
         return Response(results)
 

--- a/fixtures/db_seed.json
+++ b/fixtures/db_seed.json
@@ -15661,6 +15661,7 @@
         "attendance": {},
         "allowed_groups": [
           "worship_organizer",
+          "roster_equipments",
           "data_organizer",
           "data_counselor"
         ],
@@ -15748,7 +15749,6 @@
         "allowed_groups": [
           "children_organizer",
           "children_coworker",
-          "roster_equipments",
           "organization_participant",
           "data_organizer",
           "conference_organizer",
@@ -15795,7 +15795,6 @@
         "allowed_groups": [
           "children_organizer",
           "children_coworker",
-          "roster_equipments",
           "organization_participant",
           "data_organizer",
           "conference_organizer",
@@ -16132,7 +16131,6 @@
         "attendance": {},
         "allowed_groups": [
           "data_counselor",
-          "roster_equipments",
           "children_organizer",
           "conference_organizer"
         ],

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ hiredis==2.1.1  # https://github.com/redis/hiredis-py
 celery==5.3.1  # pyup: < 6.0  # https://github.com/celery/celery
 django-celery-beat==2.4.0  # https://github.com/celery/django-celery-beat  # 2.5.0 will need new crontabschedule migration
 flower==2.0.1  # https://github.com/mher/flower
-uvicorn[standard]==0.29.0  # https://github.com/encode/uvicorn
+uvicorn==0.29.0  # https://github.com/encode/uvicorn - removed [standard] to avoid anyio 4.x dependency
 psycopg2==2.9.9  # https://github.com/psycopg/psycopg2
 unidecode==1.3.2
 opencc==1.1.8  ## https://github.com/BYVoid/OpenCC


### PR DESCRIPTION
When auto/manually creating series of gatherings/attendances, duplication of gatherings start/end on UTC rather than local time zone will be accidentally created because of timezone ambiguity.  This MR fix that and always use `meet.infos['default_time_zone']` rather than users timezone since users can be in any timezone.

Query to find meets that does NOT have default_time_zone:
```sql
SELECT 
    id,
    slug,
    display_name,
    infos
FROM occasions_meets
WHERE is_removed = false
  AND (
    infos->>'default_time_zone' IS NULL 
    OR infos->>'default_time_zone' = ''
  )
ORDER BY id;
```